### PR TITLE
iOS 13 compatible POST for non-empty body

### DIFF
--- a/SwiftyInsta/Helpers/HttpHelper.swift
+++ b/SwiftyInsta/Helpers/HttpHelper.swift
@@ -20,7 +20,7 @@ class HttpHelper {
     /// Only ```data: Data?``` or ```body: [String: Any]``` can use as ```httpBody```
     func sendAsync(method: HTTPMethods, url: URL, body: [String: Any], header: [String: String], data: Data? = nil, completion: @escaping completionHandler) {
         HandlerSettings.shared.queue!.asyncAfter(deadline: .now() + HandlerSettings.shared.delay!.random()) {
-            var request = self.getDefaultRequest(for: url, method: method)
+            var request = self.getDefaultRequest(for: url, method: body.isEmpty ? method : .post)
             self.addHeaders(to: &request, header: header)
             //addBody(to: &request, body: body)
             
@@ -39,7 +39,7 @@ class HttpHelper {
     }
     
     func sendSync(method: HTTPMethods, url: URL, body: [String: Any], header: [String: String]) -> (Data?, HTTPURLResponse?, Error?) {
-        var request = getDefaultRequest(for: url, method: method)
+        var request = getDefaultRequest(for: url, method: body.isEmpty ? method : .post)
         var result: (Data?, HTTPURLResponse?, Error?)
         addHeaders(to: &request, header: header)
         addBody(to: &request, body: body)


### PR DESCRIPTION
iOS 13 stops `GET` requests from having a `body`.
Forcing the method dynamically to `POST` when a `body` is found fixes the problem.